### PR TITLE
fix BNet ToonInfo API usage

### DIFF
--- a/Modules/PlayerNames.lua
+++ b/Modules/PlayerNames.lua
@@ -264,7 +264,7 @@ local function fixLogin(head, id, misc, who, extra, colon)
 end
 
 local function changeBNetName(misc, id, moreMisc, fakeName, tag, colon)
-	local _, charName, _, _, _, _, _, english = BNGetToonInfo(id)
+	local _, charName, _, _, _, _, _, english = BNGetGameAccountInfo(id)
 	local left, right = "", ""
 	if chatName and charName ~= "" then
 		if storedName then storedName[id] = charName end
@@ -508,7 +508,7 @@ function Module:OnEnable()
 	if Module.db.global.noRealNames then
 		local _, n = BNGetNumFriends()
 		for i = 1, n do
-			local _, _, _, toon, id = BNGetFriendInfo(i)
+			local _, _, _, _, toon, id, _ = BNGetFriendInfo(i)
 			storedName[id] = toon
 		end
 	end


### PR DESCRIPTION
seems the BNGetFriendInfo API usage here was from 2012, see https://wow.gamepedia.com/API_BNGetFriendInfo for updated documentation (wowwiki.fandom.com seems heavily outdated)
BNGetToonInfo() doesn't exist anymore, BNGetGameAccountInfo() seems to give the desired data
https://wow.gamepedia.com/API_BNGetGameAccountInfo