### PR TITLE
fixed fatal issues in Substitutions module

### DIFF
--- a/Modules/Substitutions.lua
+++ b/Modules/Substitutions.lua
@@ -373,19 +373,19 @@ Module.patterns = {
 	-- target mana
 	["%%tm%%"] = {
 		name = L["Target's Mana"],
-		func = function() return UnitExists("target") and UnitMana("target") or L["<notarget>"] end,
+		func = function() return UnitExists("target") and UnitPower("target") or L["<notarget>"] end,
 	},
 	["%%tmm%%"] = {
 		name = L["Target's Max Mana"],
-		func = function() return UnitExists("target") and UnitManaMax("target") or L["<notarget>"] end,
+		func = function() return UnitExists("target") and UnitPowerMax("target") or L["<notarget>"] end,
 	},
 	["%%tmp%%"] = {
 		name = L["Target's Mana Percent"],
-		func = function() return UnitExists("target") and math.floor(UnitMana("target") / UnitManaMax("target") * 100) or L["<notarget>"] end,
+		func = function() return UnitExists("target") and math.floor(UnitPower("target") / UnitPowerMax("target") * 100) or L["<notarget>"] end,
 	},
 	["%%tmd%%"] = {
 		name = L["Target's Mana Deficit"],
-		func = function() return UnitExists("target") and UnitManaMax("target") - UnitMana("target") or L["<notarget>"] end,
+		func = function() return UnitExists("target") and UnitPowerMax("target") - UnitPower("target") or L["<notarget>"] end,
 	},
 	
 	-- date/time subs

--- a/Modules/Substitutions.lua
+++ b/Modules/Substitutions.lua
@@ -273,19 +273,19 @@ Module.patterns = {
 	-- players mana
 	["%%pm%%"] = {
 		name = L["Player's Mana"],
-		func = function() return UnitPower("player", 0) end,
+		func = function() return UnitPower("player") end,
 	},
 	["%%pmm%%"] = {
 		name = L["Player's Max Mana"],
-		func = function() return UnitPowerMax("player", 0) end,
+		func = function() return UnitPowerMax("player") end,
 	},
 	["%%pmp%%"] = {
 		name = L["Player's Mana Percent"],
-		func = function() return math.floor(UnitPower("player", 0) / UnitPowerMax("player", 0) * 100) end,
+		func = function() return math.floor(UnitPower("player") / UnitPowerMax("player") * 100) end,
 	},
 	["%%pmd%%"] = {
 		name = L["Player's Mana Deficit"],
-		func = function() return UnitPowerMax("player", 0) - UnitPower("player", 0) end,
+		func = function() return UnitPowerMax("player") - UnitPower("player") end,
 	},
 	
 	-- location information

--- a/Modules/Substitutions.lua
+++ b/Modules/Substitutions.lua
@@ -298,6 +298,9 @@ Module.patterns = {
 		func = function()
 			if E.MapInfo then
 				local x, y = E.MapInfo.x, E.MapInfo.y
+				if (x == nil or y == nil) then
+					return L["<no location>"]
+				end
 				return ("%d, %d"):format(math.floor((x * 100) + 0.5), math.floor((y * 100) + 0.5))
 			end
 		end,
@@ -307,6 +310,9 @@ Module.patterns = {
 		func = function()
 			if E.MapInfo then
 				local x, _ = E.MapInfo.x, _
+				if (x == nil) then
+					return L["<no location>"]
+				end
 				return math.floor((x * 100) + 0.5)
 			end
 		end,
@@ -316,6 +322,9 @@ Module.patterns = {
 		func = function()
 			if E.MapInfo then
 				local _, y = _, E.MapInfo.y
+				if (y == nil) then
+					return L["<no location>"]
+				end
 				return math.floor((y * 100) + 0.5)
 			end
 		end,


### PR DESCRIPTION
UnitMana has been deprecated and removed by Blizzard, UnitPower should be used instead
Additionally, UnitPower will return the primary resource, rather than only returning mana

inside instances, the ElvUI MapInfo object exists, but x and y are nil

these issues both cause a LUA error, which in turn causes all future chat messages to be invisible

if this PR isn't merged, anyone using this module will stop being able to see messages in a mater of minutes, until they disable the module